### PR TITLE
Fix/daoinf daoreg

### DIFF
--- a/include/daoinf.hpp
+++ b/include/daoinf.hpp
@@ -32,8 +32,6 @@ CONTRACT daoinf : public contract {
 
     ACTION reset();
 
-    ACTION initdao();
-
     ACTION adddao(const name & creator, const uint64_t & dao_id) ;
 
     ACTION storeentry(const std::vector<hypha::Content> & values, const uint64_t &dao_id);
@@ -56,7 +54,6 @@ CONTRACT daoinf : public contract {
 extern "C" void apply(uint64_t receiver, uint64_t code, uint64_t action) {
   switch (action) {
     EOSIO_DISPATCH_HELPER(daoinf, (reset)
-      (initdao)
       (storeentry)(delentry)(adddao)
     )
   }

--- a/include/daoinf.hpp
+++ b/include/daoinf.hpp
@@ -32,7 +32,7 @@ CONTRACT daoinf : public contract {
 
     ACTION reset();
 
-    ACTION initdao(const name & creator, const uint64_t & dao_id);
+    ACTION initdao();
 
     ACTION adddao(const name & creator, const uint64_t & dao_id) ;
 

--- a/include/daoreg.hpp
+++ b/include/daoreg.hpp
@@ -58,11 +58,14 @@ CONTRACT daoreg : public contract {
 
       auto primary_key () const { return dao_id; }
       uint128_t by_creator_dao () const { return (uint128_t(creator.value) << 64)  + dao.value; }
+      uint128_t by_dao_daoid () const { return (uint128_t(dao.value) << 64)  + dao_id; }
     };
 
     typedef multi_index<name("daos"), daos, 
       indexed_by<name("bycreatordao"),
-      const_mem_fun<daos, uint128_t, &daos::by_creator_dao>> 
+      const_mem_fun<daos, uint128_t, &daos::by_creator_dao>>,
+      indexed_by<name("bydaodaoid"),
+      const_mem_fun<daos, uint128_t, &daos::by_dao_daoid>>
     >dao_table;
 
 };

--- a/scripts/commands.js
+++ b/scripts/commands.js
@@ -4,6 +4,7 @@ const { createAccount, deployContract } = require('./deploy')
 const { accountExists, contractRunningSameCode } = require('./eosio-errors')
 const { setParamsValue } = require('./contract-settings')
 const { updatePermissions } = require('./permissions')
+const { developAccounts } = require("./daos-util")
 const prompt = require('prompt-sync')()
 
 
@@ -59,6 +60,11 @@ async function init () {
   console.log('SETTING CONTRACTS PARAMETERS\n')
   await setParamsValue()
   console.log('setting parameters finished\n\n')
+
+  if(isLocalNode) {
+    console.log("CREATING TEST ACCOUNTS")
+    await developAccounts()
+  }
 
 }
 

--- a/scripts/daos-util.js
+++ b/scripts/daos-util.js
@@ -1,10 +1,43 @@
+const { publicKeys, owner } = require('./config')
+const { createAccount } = require('./deploy')
+const { accountExists } = require('./eosio-errors')
+const { updatePermissions } = require('./permissions')
+
+const stakes = {
+  cpu: '40.0000 TLOS',
+  net: '40.0000 TLOS',
+  ram: 1000000
+}
+
 const daosAccounts = {
   firstuser: 'testuseraaa',
   seconduser: 'testuserbbb',
   thirduser: 'testuseryyy',
-  fourthuser: 'testuserzzz'
+  fourthuser: 'testuserzzz',
+  firstdao: "dao.org1",
+  seconddao: "dao.org2"
+}
+
+async function createDevelopAccounts (account) {
+  console.log('create develop account:', account)
+  try {
+    await createAccount({
+      account: account,
+      publicKey: publicKeys.active,
+      stakes: stakes,
+      creator: owner
+    })
+  } catch (err) {
+    accountExists(err)
+  }
+}
+
+async function developAccounts () {
+  for (var account in daosAccounts) {
+    await createDevelopAccounts(account)
+  }
 }
 
 module.exports = {
-  daosAccounts
+  daosAccounts, developAccounts
 }

--- a/scripts/daos-util.js
+++ b/scripts/daos-util.js
@@ -34,7 +34,7 @@ async function createDevelopAccounts (account) {
 
 async function developAccounts () {
   for (var account in daosAccounts) {
-    await createDevelopAccounts(account)
+    await createDevelopAccounts(daosAccounts[account])
   }
 }
 

--- a/src/daoinf.cpp
+++ b/src/daoinf.cpp
@@ -21,10 +21,6 @@ ACTION daoinf::reset () {
   while (eitr != e_t.end()) {
     eitr = e_t.erase(eitr);
   }
-}
-
-ACTION daoinf::initdao(const name & creator, const uint64_t & dao_id) {
-  require_auth(get_self());
 
   // creates the root node
   hypha::ContentGroups root_cgs {
@@ -44,27 +40,16 @@ ACTION daoinf::initdao(const name & creator, const uint64_t & dao_id) {
     }
   };
 
-  // creates the dao info node
-  hypha::ContentGroups dao_info_cgs {
-    hypha::ContentGroup {
-      hypha::Content(hypha::CONTENT_GROUP_LABEL, FIXED_DETAILS),
-      hypha::Content(CREATOR, creator),
-      hypha::Content(OWNER, get_self())
-    },
-    hypha::ContentGroup {
-      hypha::Content(hypha::CONTENT_GROUP_LABEL, VARIABLE_DETAILS),
-      hypha::Content(OWNER, get_self())
-    }
-  };
-
   hypha::Document root_doc(get_self(), get_self(), std::move(root_cgs));
   hypha::Document daos_doc(get_self(), get_self(), std::move(daos));
-  hypha::Document dao_info_doc(get_self(), get_self(), std::move(dao_info_cgs));
 
   hypha::Edge::write(get_self(), get_self(), root_doc.getHash(), daos_doc.getHash(), graph::HAS_DAOS);
 
-  hypha::Edge::write(get_self(), get_self(), daos_doc.getHash(), dao_info_doc.getHash(), name(dao_id));
-  hypha::Edge::write(get_self(), get_self(), daos_doc.getHash(), dao_info_doc.getHash(), graph::DAOS);
+}
+
+ACTION daoinf::initdao() {
+  require_auth(get_self());
+
 }
 
 ACTION daoinf::adddao(const name & creator, const uint64_t & dao_id) {

--- a/src/daoinf.cpp
+++ b/src/daoinf.cpp
@@ -47,11 +47,6 @@ ACTION daoinf::reset () {
 
 }
 
-ACTION daoinf::initdao() {
-  require_auth(get_self());
-
-}
-
 ACTION daoinf::adddao(const name & creator, const uint64_t & dao_id) {
   require_auth( has_auth(creator) ? creator : get_self() );
 

--- a/src/daoreg.cpp
+++ b/src/daoreg.cpp
@@ -17,6 +17,11 @@ ACTION daoreg::create(const name& dao, const name& creator, const std::string& i
   require_auth(creator);
   
   dao_table _dao(get_self(), get_self().value);
+  auto dao_by_id = _dao.get_index<name("bydaodaoid")>();
+  auto daoit = dao_by_id.lower_bound(uint128_t(dao.value) << 64);
+
+  check(daoit == dao_by_id.end(), "dao with same name already registered");
+
   _dao.emplace(get_self(), [&](auto& new_org){
     uint64_t dao_id = _dao.available_primary_key();
     new_org.dao_id = dao_id;

--- a/src/daoreg.cpp
+++ b/src/daoreg.cpp
@@ -24,6 +24,7 @@ ACTION daoreg::create(const name& dao, const name& creator, const std::string& i
 
   _dao.emplace(get_self(), [&](auto& new_org){
     uint64_t dao_id = _dao.available_primary_key();
+    dao_id = dao_id == 0 ? 1 : dao_id;
     new_org.dao_id = dao_id;
     new_org.dao = dao;
     new_org.creator = creator;
@@ -31,7 +32,7 @@ ACTION daoreg::create(const name& dao, const name& creator, const std::string& i
   });
 
   if (is_account(dao)) {
-    
+
     uint64_t ram_bytes = config_get_uint64(name("b.rambytes"));
 
     if (ram_bytes > 0) {

--- a/src/daoreg.cpp
+++ b/src/daoreg.cpp
@@ -14,8 +14,7 @@ ACTION daoreg::reset() {
 
 ACTION daoreg::create(const name& dao, const name& creator, const std::string& ipfs) {
 
-  check(is_account(dao), "dao has to be an account");
-  require_auth(dao);
+  require_auth( is_account(dao) ? dao : creator );
   
   dao_table _dao(get_self(), get_self().value);
   auto dao_by_id = _dao.get_index<name("bydaodaoid")>();
@@ -30,29 +29,33 @@ ACTION daoreg::create(const name& dao, const name& creator, const std::string& i
     new_org.creator = creator;
     new_org.ipfs = ipfs;
   });
+
+  if (is_account(dao)) {
+    
+    uint64_t ram_bytes = config_get_uint64(name("b.rambytes"));
+
+    if (ram_bytes > 0) {
+      action(
+          permission_level(get_self(), name("active")),
+          name("eosio"),
+          name("buyrambytes"),
+          std::make_tuple(get_self(), dao, uint32_t(ram_bytes))
+      ).send();
+    }
+
+    asset del_amount_net = config_get_asset(name("d.net"));
+    asset del_amount_cpu = config_get_asset(name("d.cpu"));
+
+    if (del_amount_net.amount > 0 || del_amount_cpu.amount > 0) {
+      action(
+          permission_level(get_self(), name("active")),
+          name("eosio"),
+          name("delegatebw"),
+          std::make_tuple(get_self(), dao, del_amount_net, del_amount_cpu, true)
+      ).send();
+    }
+  }
   
-  uint64_t ram_bytes = config_get_uint64(name("b.rambytes"));
-
-  if (ram_bytes > 0) {
-    action(
-        permission_level(get_self(), name("active")),
-        name("eosio"),
-        name("buyrambytes"),
-        std::make_tuple(get_self(), dao, uint32_t(ram_bytes))
-    ).send();
-  }
-
-  asset del_amount_net = config_get_asset(name("d.net"));
-  asset del_amount_cpu = config_get_asset(name("d.cpu"));
-
-  if (del_amount_net.amount > 0 || del_amount_cpu.amount > 0) {
-    action(
-        permission_level(get_self(), name("active")),
-        name("eosio"),
-        name("delegatebw"),
-        std::make_tuple(get_self(), dao, del_amount_net, del_amount_cpu, true)
-    ).send();
-  }
 }
 
 ACTION daoreg::update(const uint64_t& dao_id, const std::string& ipfs) {

--- a/test/daoinfo.test.js
+++ b/test/daoinfo.test.js
@@ -25,7 +25,7 @@ describe('Dao info', async function () {
   })
 
   it('Create root node and dao node', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
 
     const documentTable = await rpc.get_table_rows({
       code: daoinf,
@@ -63,7 +63,7 @@ describe('Dao info', async function () {
   })
 
   it('Create new entry', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
 
     const contentToCreate = [{
       "label": "allowed_account",
@@ -90,7 +90,7 @@ describe('Dao info', async function () {
   })
 
   it('Update entry', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
 
 
     const contentToCreate = [{
@@ -124,7 +124,7 @@ describe('Dao info', async function () {
   })
 
   it('Delete entry', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
 
     const contentToCreate = [{
       "label": "allowed_account",
@@ -173,7 +173,7 @@ describe('Dao info', async function () {
   })
 
   it('Add many entries', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
 
 
     const contentToCreate1 = [{
@@ -212,7 +212,7 @@ describe('Dao info', async function () {
   })
 
   it('Delete many entries', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
 
 
     const contentToCreate1 = [{
@@ -254,7 +254,7 @@ describe('Dao info', async function () {
 
   it('Create new dao', async () => {
 
-    await contracts.daoinf.initdao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
 
     await contracts.daoinf.adddao("newdao", 2,{ authorization: `${daoinf}@active` })
 
@@ -313,7 +313,7 @@ describe('Dao info', async function () {
   })
 
   it('Create new entry in other dao', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1,{ authorization: `${daoinf}@active` })
     await contracts.daoinf.adddao("newdao", 2,{ authorization: `${daoinf}@active` })
 
     const contentToCreate = [{
@@ -341,7 +341,7 @@ describe('Dao info', async function () {
   })
 
   it('Update entry in other dao', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
     await contracts.daoinf.adddao("newdao", 2,{ authorization: `${daoinf}@active` })
 
     const contentToCreate = [{
@@ -375,7 +375,7 @@ describe('Dao info', async function () {
   })
 
   it('Delete entry in other dao', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
     await contracts.daoinf.adddao("newdao", 2,{ authorization: `${daoinf}@active` })
 
     const contentToCreate = [{
@@ -427,7 +427,7 @@ describe('Dao info', async function () {
   })
 
   it('Add many entries in other dao', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
 
 
     const contentToCreate1 = [{
@@ -466,7 +466,7 @@ describe('Dao info', async function () {
   })
 
   it('Delete many entries in other dao', async () => {
-    await contracts.daoinf.initdao("edwintestnet", 1, { authorization: `${daoinf}@active` })
+    await contracts.daoinf.adddao("edwintestnet", 1, { authorization: `${daoinf}@active` })
     await contracts.daoinf.adddao("newdao", 2,{ authorization: `${daoinf}@active` })
 
     const contentToCreate1 = [{

--- a/test/daoreg.test.js
+++ b/test/daoreg.test.js
@@ -83,7 +83,7 @@ describe('Dao registry', async function () {
 
         assert.deepStrictEqual(dao_table.rows, [
             {
-                dao_id: 0,
+                dao_id: 1,
                 dao: firstdao,
                 creator: firstuser,
                 ipfs: 'HASH_1',
@@ -134,7 +134,7 @@ describe('Dao registry', async function () {
 
         // update DAO by the creator
         await contracts.daoreg.update(
-            0,
+            1,
             'NEW_HASH_1',
             { authorization: `${firstuser}@active` }
         )
@@ -143,7 +143,7 @@ describe('Dao registry', async function () {
         let updateIpfsOnlyOwner = true
         try {
             await contracts.daoreg.update(
-                0,
+                1,
                 'NEW_HASH_2',
                 { authorization: `${seconduser}@active` })
             updateIpfsOnlyOwner = false
@@ -160,7 +160,7 @@ describe('Dao registry', async function () {
         let updateIpfsIfFound = true
         try {
             await contracts.daoreg.update(
-                1,
+                2,
                 'NEW_HASH3',
                 { authorization: `${daoreg}@active` })
             updateIpfsIfFound = false
@@ -183,7 +183,7 @@ describe('Dao registry', async function () {
 
         assert.deepStrictEqual(dao_table.rows, [
             {
-                dao_id: 0,
+                dao_id: 1,
                 dao: firstdao,
                 creator: firstuser,
                 ipfs: 'NEW_HASH_1',
@@ -209,7 +209,7 @@ describe('Dao registry', async function () {
         let deleteDaoByCreator = true
         try {
             await contracts.daoreg.delorg(
-                0,
+                1,
                 { authorization: `${firstuser}@active` })
             deleteDaoByCreator = false
         } catch (error) {
@@ -225,7 +225,7 @@ describe('Dao registry', async function () {
         let deleteDaoIfFound = true
         try {
             await contracts.daoreg.delorg(
-                1,
+                2,
                 { authorization: `${daoreg}@active` })
             deleteDaoIfFound = false
         } catch (error) {
@@ -239,7 +239,7 @@ describe('Dao registry', async function () {
 
         // delete DAO
         await contracts.daoreg.delorg(
-            0,
+            1,
             { authorization: `${daoreg}@active` }
         )
 
@@ -268,7 +268,7 @@ describe('Dao registry', async function () {
         let upsertattrsByCreator = true
         try {
             await contracts.daoreg.upsertattrs(
-                0,
+                1,
                 [
                     { first: "first attribute", second: ['uint64', 001] },
                     { first: "second attribute", second: ['string', 'DAOO'] },
@@ -288,7 +288,7 @@ describe('Dao registry', async function () {
         let upsertattrsDaoIfFound = true
         try {
             await contracts.daoreg.upsertattrs(
-                1,
+                2,
                 [
                     { first: "first attribute", second: ['uint64', 007] },
                     { first: "second attribute", second: ['string', 'this should fail'] },
@@ -306,7 +306,7 @@ describe('Dao registry', async function () {
 
         // add some attributes
         await contracts.daoreg.upsertattrs(
-            0,
+            1,
             [
                 { first: "first attribute", second: ['uint64', 001] },
                 { first: "second attribute", second: ['string', 'DAOO'] },
@@ -316,7 +316,7 @@ describe('Dao registry', async function () {
 
         // update attribute
         await contracts.daoreg.upsertattrs(
-            0,
+            1,
             [
                 { first: "first attribute", second: ['string', 'updated attribute'] }
             ],
@@ -335,7 +335,7 @@ describe('Dao registry', async function () {
 
         assert.deepStrictEqual(dao_table.rows, [
             {
-                dao_id: 0,
+                dao_id: 1,
                 dao: firstdao,
                 creator: firstuser,
                 ipfs: 'HASH_1',
@@ -371,7 +371,7 @@ describe('Dao registry', async function () {
 
         // add some attributes
         await contracts.daoreg.upsertattrs(
-            0,
+            1,
             [
                 { first: "first attribute", second: ['uint64', 001] },
                 { first: "second attribute", second: ['string', 'DAOO'] },
@@ -384,7 +384,7 @@ describe('Dao registry', async function () {
         let deleteAttrsByCreator = true
         try {
             await contracts.daoreg.delattrs(
-                0,
+                1,
                 ['first attribute'],
                 { authorization: `${seconduser}@active` })
             deleteAttrsByCreator = false
@@ -401,7 +401,7 @@ describe('Dao registry', async function () {
         let deleteAttrsDaoIfFound = true
         try {
             await contracts.daoreg.upsertattrs(
-                1,
+                2,
                 [
                     { first: "first attribute", second: ['uint64', 007] },
                     { first: "second attribute", second: ['string', 'this should fail'] },
@@ -419,7 +419,7 @@ describe('Dao registry', async function () {
 
         // delete attributes, fifth attribute does not exists
         await contracts.daoreg.delattrs(
-            0,
+            1,
             ['first attribute', 'fourth attribute', 'fifth attribute'],
             { authorization: `${firstuser}@active` }
         )
@@ -436,7 +436,7 @@ describe('Dao registry', async function () {
 
         assert.deepStrictEqual(dao_table.rows, [
             {
-                dao_id: 0,
+                dao_id: 1,
                 dao: firstdao,
                 creator: firstuser,
                 ipfs: 'HASH_1',
@@ -474,7 +474,7 @@ describe('Dao registry', async function () {
         let addTokenDaoIfFound = true
         try {
             await contracts.daoreg.addtoken(
-                1,
+                2,
                 'token.c',
                 `4,CTK`,
                 { authorization: `${firstuser}@active` })
@@ -492,7 +492,7 @@ describe('Dao registry', async function () {
         let addTokenByCreator = true
         try {
             await contracts.daoreg.addtoken(
-                0,
+                1,
                 'token.c',
                 `4,CTK`,
                 { authorization: `${seconduser}@active` })
@@ -508,7 +508,7 @@ describe('Dao registry', async function () {
 
         // add token
         await contracts.daoreg.addtoken(
-            0,
+            1,
             'token.c',
             `4,CTK`,
             { authorization: `${firstuser}@active` }
@@ -518,7 +518,7 @@ describe('Dao registry', async function () {
         let tokenExists = true
         try {
             await contracts.daoreg.addtoken(
-                0,
+                1,
                 'token.c',
                 `4,CTK`,
                 { authorization: `${firstuser}@active` })
@@ -543,7 +543,7 @@ describe('Dao registry', async function () {
         console.log(JSON.stringify(dao_table, null, 2))
         assert.deepStrictEqual(dao_table.rows, [
             {
-                dao_id: 0,
+                dao_id: 1,
                 dao: firstdao,
                 creator: firstuser,
                 ipfs: 'HASH_1',

--- a/test/daoreg.test.js
+++ b/test/daoreg.test.js
@@ -5,7 +5,7 @@ const { daosAccounts } = require('../scripts/daos-util')
 const { assertError } = require('../scripts/eosio-errors')
 const { contractNames, isLocalNode, sleep } = require('../scripts/config')
 const { setParamsValue } = require('../scripts/contract-settings')
-const { AssertionError } = require('assert/strict')
+const { AssertionError } = require('assert')
 
 const { daoreg, daoinf } = contractNames
 const { firstuser, seconduser, thirduser, fourthuser } = daosAccounts
@@ -93,6 +93,34 @@ describe('Dao registry', async function () {
         ])
 
         assert.deepStrictEqual(daoCreation, true)
+    })
+
+    it('Create DAO', async function () {
+        await contracts.daoreg.create(
+            'dao.org1',
+            daoreg,
+            'HASH_1',
+            { authorization: `${daoreg}@active` }
+        )
+
+        let daoCreatedTwice = false;
+        try {
+            await contracts.daoreg.create(
+                'dao.org1',
+                daoreg,
+                'HASH_2',
+                { authorization: `${daoreg}@active` })
+            daoCreatedTwice = true
+        } catch (error) {
+            assertError({
+                error,
+                textInside: `dao with same name already registered`,
+                message: 'can not create dao with same name (expected)',
+                throwError: true
+            })
+        }
+
+        assert.deepStrictEqual(daoCreatedTwice, false)
     })
 
     it('Update IPFS DAO', async function () {

--- a/test/daoreg.test.js
+++ b/test/daoreg.test.js
@@ -95,7 +95,7 @@ describe('Dao registry', async function () {
         assert.deepStrictEqual(daoCreation, true)
     })
 
-    it('Create DAO', async function () {
+    it('Create another DAO with same name', async function () {
         await contracts.daoreg.create(
             'dao.org1',
             daoreg,


### PR DESCRIPTION
in daoinf:
- root and dao nodes created only in reset

in daoreg:
- ask authorization of dao for creation if is an account
- daos with same name must no exist
- add index bydaoid (dao+daoid) 
- daoid must start at one

in scripts:
- create test accounts if is running at local node